### PR TITLE
Added implementation to exclude unauthorized streams from discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0
+  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.[#23](https://github.com/singer-io/tap-teamwork/pull/23)
+
 ## 0.1.0
   * Updated python version. [#19](https://github.com/singer-io/tap-teamwork/pull/19)
   * Added integration tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.2.0
-  * Streams the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error.[#23](https://github.com/singer-io/tap-teamwork/pull/23)
+  * Streams that the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#23](https://github.com/singer-io/tap-teamwork/pull/23)
 
 ## 0.1.0
   * Updated python version. [#19](https://github.com/singer-io/tap-teamwork/pull/19)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     py_modules=["tap_teamwork"],
     install_requires=[
         "singer-python==6.8.0",
-        "requests==2.33.1",
+        "requests==2.34.2",
         "backoff==2.2.1"
     ],
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-teamwork",
-    version="0.1.0",
+    version="0.2.0",
     description="Singer.io tap for extracting data from Teamwork API",
     author="Stitch",
     url="http://singer.io",

--- a/tap_teamwork/__init__.py
+++ b/tap_teamwork/__init__.py
@@ -9,12 +9,12 @@ LOGGER = singer.get_logger()
 
 REQUIRED_CONFIG_KEYS = ["api_key", "start_date", "subdomain"]
 
-def do_discover():
+def do_discover(client):
     """
     Discover and emit the catalog to stdout
     """
     LOGGER.info("Starting discover")
-    catalog = discover()
+    catalog = discover(client)
     json.dump(catalog.to_dict(), sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
@@ -28,7 +28,7 @@ def main():
 
     with Client(parsed_args.config) as client:
         if parsed_args.discover:
-            do_discover()
+            do_discover(client)
         elif parsed_args.catalog:
             sync(
                 client=client,

--- a/tap_teamwork/discover.py
+++ b/tap_teamwork/discover.py
@@ -2,15 +2,70 @@ import singer
 from singer import metadata
 from singer.catalog import Catalog, CatalogEntry, Schema
 from tap_teamwork.schema import get_schemas
+from tap_teamwork.streams import STREAMS
+from tap_teamwork.exceptions import teamworkForbiddenError
 
 LOGGER = singer.get_logger()
 
 
-def discover() -> Catalog:
+def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+    Child streams always return True from check_access(), so this loop
+    effectively identifies only inaccessible parent streams.
+    Child stream removal is handled separately by _prune_inaccessible_children().
+    Raises teamworkForbiddenError if no parent streams are accessible.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_obj in STREAMS.items()
+        if stream_name in schemas
+        and not stream_obj(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise teamworkForbiddenError(
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
+        )
+    elif inaccessible_streams:
+        LOGGER.warning(
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        stream_obj = stream_cls()
+        if name in schemas and stream_obj.parent and stream_obj.parent not in schemas:
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
+                name, stream_obj.parent,
+            )
+            schemas.pop(name, None)
+            field_metadata.pop(name, None)
+
+
+def discover(client) -> Catalog:
     """
     Run the discovery mode, prepare the catalog file and return the catalog.
+    Access to each stream is verified using the provided client and streams
+    the credentials cannot read are excluded from the returned catalog.
     """
     schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
+
     catalog = Catalog([])
 
     for stream_name, schema_dict in schemas.items():

--- a/tap_teamwork/discover.py
+++ b/tap_teamwork/discover.py
@@ -28,7 +28,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         schemas.pop(stream_name, None)
         field_metadata.pop(stream_name, None)
 
-    _prune_inaccessible_children(schemas, field_metadata)
+    inaccessible_streams.extend(_prune_inaccessible_children(schemas, field_metadata))
 
     if not schemas:
         raise teamworkForbiddenError(
@@ -36,7 +36,7 @@ def _apply_access_checks(client, schemas: dict, field_metadata: dict) -> None:
         )
     elif inaccessible_streams:
         LOGGER.warning(
-            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            "Unauthorized streams excluded from catalog: %s",
             ", ".join(inaccessible_streams),
         )
 
@@ -46,6 +46,7 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
     Remove child streams from the catalog whose parent stream was excluded.
     Mutates schemas and field_metadata in place.
     """
+    to_remove = []
     for name, stream_cls in list(STREAMS.items()):
         parent = getattr(stream_cls, "parent", "")
         if name in schemas and parent and parent not in schemas:
@@ -55,6 +56,9 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
             )
             schemas.pop(name, None)
             field_metadata.pop(name, None)
+            to_remove.append(name)
+
+    return to_remove
 
 
 def discover(client) -> Catalog:

--- a/tap_teamwork/discover.py
+++ b/tap_teamwork/discover.py
@@ -47,11 +47,11 @@ def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
     Mutates schemas and field_metadata in place.
     """
     for name, stream_cls in list(STREAMS.items()):
-        stream_obj = stream_cls()
-        if name in schemas and stream_obj.parent and stream_obj.parent not in schemas:
+        parent = getattr(stream_cls, "parent", "")
+        if name in schemas and parent and parent not in schemas:
             LOGGER.warning(
                 "Stream '%s' excluded from catalog because its parent stream '%s' is not accessible.",
-                name, stream_obj.parent,
+                name, parent,
             )
             schemas.pop(name, None)
             field_metadata.pop(name, None)

--- a/tap_teamwork/streams/abstracts.py
+++ b/tap_teamwork/streams/abstracts.py
@@ -16,6 +16,8 @@ from singer import (
     utils,
 )
 
+from tap_teamwork.exceptions import teamworkForbiddenError
+
 LOGGER = get_logger()
 
 
@@ -167,6 +169,32 @@ class BaseStream(ABC):
         """Return the starting timestamp from config, or fallback epoch."""
         cfg = getattr(self.client, "config", {}) or {}
         return cfg.get("start_date", "1970-01-01T00:00:00Z")
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+        Returns True if accessible, False if a 403 Forbidden error is raised.
+        Child streams always return True (access is governed by the parent check).
+        """
+        if self.parent:
+            return True
+
+        url = self.get_url_endpoint()
+
+        try:
+            self.client.get(
+                endpoint=url,
+                params=self.params,
+                headers=self.headers.copy(),
+            )
+            return True
+        except teamworkForbiddenError as exc:
+            LOGGER.warning(
+                "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
+                self.tap_stream_id,
+                str(exc),
+            )
+            return False
 
 
 class IncrementalStream(BaseStream):

--- a/tests/base.py
+++ b/tests/base.py
@@ -18,6 +18,7 @@ class teamworkBaseTest(BaseCase):
     in tap-tester tests. Shared tap-specific methods (as needed).
     """    
     start_date = "2019-01-01T00:00:00Z"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
 
     @staticmethod
     def tap_name():
@@ -174,6 +175,14 @@ class teamworkBaseTest(BaseCase):
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             }
+        }
+
+    def expected_stream_names(self):
+        """The expected stream names and exclude forbidden streams."""
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
         }
 
     @staticmethod

--- a/tests/unittests/test_bookmarks.py
+++ b/tests/unittests/test_bookmarks.py
@@ -1,0 +1,115 @@
+"""
+Unit tests for bookmark read/write helpers in IncrementalStream.
+
+Covers:
+- Reading bookmarks (existing, fallback to start_date)
+- Writing bookmarks (advancement, non-regression)
+- _parse_utc / _fmt round-trip
+"""
+
+import pytest
+from unittest.mock import MagicMock
+from tap_teamwork.streams.abstracts import IncrementalStream
+
+
+# ─── Concrete test stream ──────────────────────────────────────────
+
+class StubIncremental(IncrementalStream):
+    tap_stream_id = "stub_incremental"
+    replication_keys = ["updatedAt"]
+    key_properties = ["id"]
+    replication_method = "INCREMENTAL"
+
+
+@pytest.fixture
+def client():
+    c = MagicMock()
+    c.config = {"start_date": "2024-01-01T00:00:00Z"}
+    c.base_url = "https://test.teamwork.com"
+    c.build_url.side_effect = lambda p: f"{c.base_url}/{p.lstrip('/')}"
+    return c
+
+
+@pytest.fixture
+def catalog():
+    cat = MagicMock()
+    cat.schema.to_dict.return_value = {"type": "object", "properties": {"id": {"type": "string"}}}
+    cat.metadata = []
+    return cat
+
+
+@pytest.fixture
+def stream(client, catalog):
+    return StubIncremental(client=client, catalog=catalog)
+
+
+# ─── get_bookmark ──────────────────────────────────────────────────
+
+class TestGetBookmark:
+
+    def test_existing_bookmark_returned(self, stream):
+        state = {"bookmarks": {"stub_incremental": {"updatedAt": "2025-06-01T00:00:00Z"}}}
+        result = stream.get_bookmark(state, "stub_incremental")
+        assert result == "2025-06-01T00:00:00Z"
+
+    def test_fallback_to_start_date(self, stream):
+        state = {}
+        result = stream.get_bookmark(state, "stub_incremental")
+        assert result == "2024-01-01T00:00:00Z"
+
+    def test_custom_key(self, stream):
+        state = {"bookmarks": {"stub_incremental": {"custom_key": "2025-03-01T00:00:00Z"}}}
+        result = stream.get_bookmark(state, "stub_incremental", key="custom_key")
+        assert result == "2025-03-01T00:00:00Z"
+
+
+# ─── write_bookmark ────────────────────────────────────────────────
+
+class TestWriteBookmark:
+
+    def test_advances_bookmark(self, stream):
+        state = {"bookmarks": {"stub_incremental": {"updatedAt": "2024-06-01T00:00:00Z"}}}
+        result = stream.write_bookmark(state, "stub_incremental", value="2025-01-01T00:00:00Z")
+        assert result["bookmarks"]["stub_incremental"]["updatedAt"] >= "2025-01-01"
+
+    def test_does_not_regress(self, stream):
+        state = {"bookmarks": {"stub_incremental": {"updatedAt": "2025-06-01T00:00:00Z"}}}
+        result = stream.write_bookmark(state, "stub_incremental", value="2024-01-01T00:00:00Z")
+        assert result["bookmarks"]["stub_incremental"]["updatedAt"] >= "2025-06-01"
+
+    def test_new_bookmark_written(self, stream):
+        state = {}
+        result = stream.write_bookmark(state, "stub_incremental", value="2025-03-15T12:00:00Z")
+        assert "bookmarks" in result
+        assert "stub_incremental" in result["bookmarks"]
+
+
+# ─── _parse_utc ────────────────────────────────────────────────────
+
+class TestParseUtc:
+
+    def test_valid_iso_string(self, stream):
+        dt = stream._parse_utc("2025-06-01T12:00:00Z")
+        assert dt is not None
+
+    def test_none_returns_none(self, stream):
+        assert stream._parse_utc(None) is None
+
+    def test_empty_string_returns_none(self, stream):
+        assert stream._parse_utc("") is None
+
+    def test_null_string_returns_none(self, stream):
+        assert stream._parse_utc("null") is None
+
+
+# ─── _minus_one_second_str ─────────────────────────────────────────
+
+class TestMinusOneSecond:
+
+    def test_subtracts_one_second(self, stream):
+        result = stream._minus_one_second_str("2025-06-01T00:00:01Z")
+        assert result is not None
+        assert "2025-06-01T00:00:00" in result
+
+    def test_invalid_returns_none(self, stream):
+        assert stream._minus_one_second_str("not-a-date") is None

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,195 @@
+"""
+Unit tests for discovery with stream access checking.
+
+Covers:
+- All streams accessible → full catalog
+- Partial access (some 403s) → excluded streams
+- Complete denial (all 403s) → teamworkForbiddenError raised
+- Parent-child cascading exclusion
+- Catalog structure validation
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from tap_teamwork.discover import _apply_access_checks, _prune_inaccessible_children, discover
+from tap_teamwork.exceptions import teamworkForbiddenError
+from tap_teamwork.streams import STREAMS
+
+
+# ─── helpers ────────────────────────────────────────────────────────
+
+def _make_client():
+    """Return a mock client suitable for stream instantiation."""
+    client = MagicMock()
+    client.base_url = "https://test.teamwork.com"
+    client.config = {"start_date": "2024-01-01T00:00:00Z", "api_key": "tok"}
+    client.build_url.side_effect = lambda p: f"{client.base_url}/{p.lstrip('/')}"
+    client.get.return_value = {}
+    return client
+
+
+def _schemas_and_metadata():
+    """Return minimal schemas / field_metadata dicts keyed by every stream."""
+    schemas = {name: {"type": "object", "properties": {"id": {"type": "string"}}} for name in STREAMS}
+    field_metadata = {name: [] for name in STREAMS}
+    return schemas, field_metadata
+
+
+# ─── _apply_access_checks ──────────────────────────────────────────
+
+class TestApplyAccessChecks:
+
+    @patch("tap_teamwork.discover.STREAMS")
+    def test_all_streams_accessible(self, mock_streams):
+        """When every stream is accessible the catalog keeps all streams."""
+        client = _make_client()
+
+        # Build a mock STREAMS dict where every stream's check_access returns True
+        mock_cls_a = MagicMock()
+        mock_cls_a.return_value.check_access.return_value = True
+        mock_cls_a.return_value.parent = ""
+        mock_cls_b = MagicMock()
+        mock_cls_b.return_value.check_access.return_value = True
+        mock_cls_b.return_value.parent = ""
+
+        mock_streams.items.return_value = [("stream_a", mock_cls_a), ("stream_b", mock_cls_b)]
+
+        schemas = {"stream_a": {}, "stream_b": {}}
+        fm = {"stream_a": [], "stream_b": []}
+
+        _apply_access_checks(client, schemas, fm)
+
+        assert "stream_a" in schemas
+        assert "stream_b" in schemas
+
+    @patch("tap_teamwork.discover.STREAMS")
+    def test_partial_access_excludes_forbidden_streams(self, mock_streams):
+        """Streams returning 403 are removed; others remain."""
+        client = _make_client()
+
+        accessible = MagicMock()
+        accessible.return_value.check_access.return_value = True
+        accessible.return_value.parent = ""
+        forbidden = MagicMock()
+        forbidden.return_value.check_access.return_value = False
+        forbidden.return_value.parent = ""
+
+        mock_streams.items.return_value = [
+            ("projects", accessible),
+            ("tasks", forbidden),
+        ]
+
+        schemas = {"projects": {}, "tasks": {}}
+        fm = {"projects": [], "tasks": []}
+
+        _apply_access_checks(client, schemas, fm)
+
+        assert "projects" in schemas
+        assert "tasks" not in schemas
+        assert "tasks" not in fm
+
+    @patch("tap_teamwork.discover.STREAMS")
+    def test_all_streams_forbidden_raises(self, mock_streams):
+        """If every parent stream is forbidden, a teamworkForbiddenError is raised."""
+        client = _make_client()
+
+        forbidden_a = MagicMock()
+        forbidden_a.return_value.check_access.return_value = False
+        forbidden_a.return_value.parent = ""
+        forbidden_b = MagicMock()
+        forbidden_b.return_value.check_access.return_value = False
+        forbidden_b.return_value.parent = ""
+
+        mock_streams.items.return_value = [
+            ("stream_a", forbidden_a),
+            ("stream_b", forbidden_b),
+        ]
+
+        schemas = {"stream_a": {}, "stream_b": {}}
+        fm = {"stream_a": [], "stream_b": []}
+
+        with pytest.raises(teamworkForbiddenError):
+            _apply_access_checks(client, schemas, fm)
+
+
+# ─── _prune_inaccessible_children ─────────────────────────────────
+
+class TestPruneInaccessibleChildren:
+
+    def test_child_removed_when_parent_missing(self):
+        """Child streams are pruned when their parent is not in schemas."""
+        schemas = {"ticket_details": {}, "projects": {}}
+        fm = {"ticket_details": [], "projects": []}
+
+        # tickets is not in schemas, so ticket_details (parent=tickets) should be removed
+        _prune_inaccessible_children(schemas, fm)
+
+        assert "ticket_details" not in schemas
+        assert "ticket_details" not in fm
+        assert "projects" in schemas
+
+    def test_child_kept_when_parent_present(self):
+        """Child streams are kept when their parent is in schemas."""
+        schemas = {"tickets": {}, "ticket_details": {}}
+        fm = {"tickets": [], "ticket_details": []}
+
+        _prune_inaccessible_children(schemas, fm)
+
+        assert "ticket_details" in schemas
+
+    def test_multiple_children_of_same_parent_pruned(self):
+        """All children of a missing parent are removed."""
+        # spaces has two children: pages and collaborators
+        schemas = {"projects": {}, "pages": {}, "collaborators": {}}
+        fm = {"projects": [], "pages": [], "collaborators": []}
+
+        # spaces is not in schemas → pages and collaborators should be pruned
+        _prune_inaccessible_children(schemas, fm)
+
+        assert "pages" not in schemas
+        assert "collaborators" not in schemas
+        assert "projects" in schemas
+
+
+# ─── discover() integration ────────────────────────────────────────
+
+class TestDiscover:
+
+    @patch("tap_teamwork.discover._apply_access_checks")
+    @patch("tap_teamwork.discover.get_schemas")
+    def test_discover_returns_catalog(self, mock_get_schemas, mock_access):
+        """discover() returns a Catalog with entries for every schema."""
+        schemas = {
+            "projects": {"type": "object", "properties": {"id": {"type": "string"}}},
+        }
+        fm = {
+            "projects": [
+                {"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}},
+            ],
+        }
+        mock_get_schemas.return_value = (schemas, fm)
+        mock_access.return_value = None  # no-op
+
+        client = _make_client()
+        catalog = discover(client)
+
+        assert len(catalog.streams) == 1
+        assert catalog.streams[0].tap_stream_id == "projects"
+
+    @patch("tap_teamwork.discover.get_schemas")
+    def test_discover_calls_access_checks(self, mock_get_schemas):
+        """discover() invokes _apply_access_checks with the client."""
+        mock_get_schemas.return_value = ({}, {})
+        client = _make_client()
+
+        with patch("tap_teamwork.discover._apply_access_checks") as mock_ac:
+            # Need at least one schema after access check to avoid error
+            def keep_schemas(c, s, f):
+                s["projects"] = {"type": "object", "properties": {"id": {"type": "string"}}}
+                f["projects"] = [{"breadcrumb": (), "metadata": {"table-key-properties": ["id"]}}]
+            mock_ac.side_effect = keep_schemas
+
+            discover(client)
+            mock_ac.assert_called_once()
+            assert mock_ac.call_args[0][0] is client

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -28,11 +28,6 @@ def _make_client():
     return client
 
 
-def _schemas_and_metadata():
-    """Return minimal schemas / field_metadata dicts keyed by every stream."""
-    schemas = {name: {"type": "object", "properties": {"id": {"type": "string"}}} for name in STREAMS}
-    field_metadata = {name: [] for name in STREAMS}
-    return schemas, field_metadata
 
 
 # ─── _apply_access_checks ──────────────────────────────────────────

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -165,7 +165,7 @@ class TestApplyAccessChecks:
         _apply_access_checks(client, schemas, fm)
 
         mock_warning.assert_called_once_with(
-            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            "Unauthorized streams excluded from catalog: %s",
             "tasks",
         )
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -14,7 +14,6 @@ from unittest.mock import MagicMock, patch
 
 from tap_teamwork.discover import _apply_access_checks, _prune_inaccessible_children, discover
 from tap_teamwork.exceptions import teamworkForbiddenError
-from tap_teamwork.streams import STREAMS
 
 
 # ─── helpers ────────────────────────────────────────────────────────

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -110,6 +110,65 @@ class TestApplyAccessChecks:
         with pytest.raises(teamworkForbiddenError):
             _apply_access_checks(client, schemas, fm)
 
+    @patch("tap_teamwork.discover.STREAMS")
+    def test_all_streams_forbidden_raises_expected_message(self, mock_streams):
+        """Raises the exact no-access error text when no streams remain."""
+        client = _make_client()
+
+        forbidden_a = MagicMock()
+        forbidden_a.parent = ""
+        forbidden_a.return_value.check_access.return_value = False
+        forbidden_a.return_value.parent = ""
+        forbidden_b = MagicMock()
+        forbidden_b.parent = ""
+        forbidden_b.return_value.check_access.return_value = False
+        forbidden_b.return_value.parent = ""
+
+        mock_streams.items.return_value = [
+            ("stream_a", forbidden_a),
+            ("stream_b", forbidden_b),
+        ]
+
+        schemas = {"stream_a": {}, "stream_b": {}}
+        fm = {"stream_a": [], "stream_b": []}
+
+        with pytest.raises(teamworkForbiddenError) as exc_info:
+            _apply_access_checks(client, schemas, fm)
+
+        assert str(exc_info.value) == (
+            "No streams are accessible. Ensure the credentials have read permission for at least one stream."
+        )
+
+    @patch("tap_teamwork.discover.LOGGER.warning")
+    @patch("tap_teamwork.discover.STREAMS")
+    def test_partial_access_logs_excluded_streams_message(self, mock_streams, mock_warning):
+        """Logs the exact 403 excluded-streams warning message."""
+        client = _make_client()
+
+        accessible = MagicMock()
+        accessible.parent = ""
+        accessible.return_value.check_access.return_value = True
+        accessible.return_value.parent = ""
+        forbidden = MagicMock()
+        forbidden.parent = ""
+        forbidden.return_value.check_access.return_value = False
+        forbidden.return_value.parent = ""
+
+        mock_streams.items.return_value = [
+            ("projects", accessible),
+            ("tasks", forbidden),
+        ]
+
+        schemas = {"projects": {}, "tasks": {}}
+        fm = {"projects": [], "tasks": []}
+
+        _apply_access_checks(client, schemas, fm)
+
+        mock_warning.assert_called_once_with(
+            "These streams have been excluded due to HTTP-Error-Code:403 Forbidden: %s",
+            "tasks",
+        )
+
 
 # ─── _prune_inaccessible_children ─────────────────────────────────
 

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -41,9 +41,11 @@ class TestApplyAccessChecks:
 
         # Build a mock STREAMS dict where every stream's check_access returns True
         mock_cls_a = MagicMock()
+        mock_cls_a.parent = ""
         mock_cls_a.return_value.check_access.return_value = True
         mock_cls_a.return_value.parent = ""
         mock_cls_b = MagicMock()
+        mock_cls_b.parent = ""
         mock_cls_b.return_value.check_access.return_value = True
         mock_cls_b.return_value.parent = ""
 
@@ -63,9 +65,11 @@ class TestApplyAccessChecks:
         client = _make_client()
 
         accessible = MagicMock()
+        accessible.parent = ""
         accessible.return_value.check_access.return_value = True
         accessible.return_value.parent = ""
         forbidden = MagicMock()
+        forbidden.parent = ""
         forbidden.return_value.check_access.return_value = False
         forbidden.return_value.parent = ""
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -11,7 +11,7 @@ Covers:
 """
 
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from tap_teamwork.streams.abstracts import IncrementalStream, FullTableStream
 from tap_teamwork.exceptions import teamworkForbiddenError
 

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -148,6 +148,19 @@ class TestCheckAccess:
         stream = StubIncremental(client=mock_client, catalog=mock_catalog)
         assert stream.check_access() is False
 
+    @patch("tap_teamwork.streams.abstracts.LOGGER.warning")
+    def test_forbidden_stream_logs_expected_message(self, mock_warning, mock_client, mock_catalog):
+        """check_access logs the stream id and error text when access is forbidden."""
+        mock_client.get.side_effect = teamworkForbiddenError("Forbidden")
+        stream = StubIncremental(client=mock_client, catalog=mock_catalog)
+
+        assert stream.check_access() is False
+        mock_warning.assert_called_once_with(
+            "Unauthorized Stream: %s, excluding from catalog. HTTP-Error-Message:'%s'",
+            "stub_incremental",
+            "Forbidden",
+        )
+
     def test_child_stream_always_accessible(self, mock_client, mock_catalog):
         """Child streams always return True from check_access."""
         stream = StubChild(client=mock_client, catalog=mock_catalog)

--- a/tests/unittests/test_sync.py
+++ b/tests/unittests/test_sync.py
@@ -1,0 +1,192 @@
+"""
+Unit tests for sync logic.
+
+Covers:
+- Incremental sync filtering by bookmark
+- Full table sync behaviour
+- Bookmark advancement after sync
+- Child stream synchronisation
+- Sync orchestration (currently_syncing tracking)
+- check_access method on base stream
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+from tap_teamwork.streams.abstracts import IncrementalStream, FullTableStream
+from tap_teamwork.exceptions import teamworkForbiddenError
+
+
+# ─── concrete stubs ────────────────────────────────────────────────
+
+class StubIncremental(IncrementalStream):
+    tap_stream_id = "stub_incremental"
+    replication_keys = ["updatedAt"]
+    key_properties = ["id"]
+    replication_method = "INCREMENTAL"
+    path = "api/v3/stubs.json"
+    data_key = "stubs"
+
+
+class StubFullTable(FullTableStream):
+    tap_stream_id = "stub_full"
+    replication_keys = []
+    key_properties = ["id"]
+    replication_method = "FULL_TABLE"
+    path = "api/v3/full_stubs.json"
+    data_key = "full_stubs"
+
+
+class StubChild(FullTableStream):
+    tap_stream_id = "stub_child"
+    parent = "stub_full"
+    replication_keys = []
+    key_properties = ["id"]
+    replication_method = "FULL_TABLE"
+    path = "api/v3/full_stubs/{parentId}/children.json"
+    data_key = "children"
+
+
+# ─── fixtures ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+    client.base_url = "https://test.teamwork.com"
+    client.config = {"start_date": "2024-01-01T00:00:00Z"}
+    client.build_url.side_effect = lambda p: f"{client.base_url}/{p.lstrip('/')}"
+    client.get.return_value = {"stubs": [], "full_stubs": [], "children": []}
+    return client
+
+
+@pytest.fixture
+def mock_catalog():
+    cat = MagicMock()
+    cat.schema.to_dict.return_value = {
+        "type": "object",
+        "properties": {"id": {"type": "string"}, "updatedAt": {"type": "string"}},
+    }
+    cat.metadata = []
+    return cat
+
+
+# ─── incremental sync ─────────────────────────────────────────────
+
+class TestIncrementalSync:
+
+    @patch("tap_teamwork.streams.abstracts.write_record")
+    @patch("tap_teamwork.streams.abstracts.metrics.record_counter")
+    def test_writes_records_newer_than_bookmark(self, mock_counter, mock_write, mock_client, mock_catalog):
+        mock_counter.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_counter.return_value.__exit__ = MagicMock(return_value=False)
+
+        stream = StubIncremental(client=mock_client, catalog=mock_catalog)
+        stream.is_selected = MagicMock(return_value=True)
+        stream.get_records = MagicMock(return_value=[
+            {"id": "1", "updatedAt": "2025-06-01T00:00:00Z"},
+            {"id": "2", "updatedAt": "2025-06-02T00:00:00Z"},
+        ])
+
+        state = {"bookmarks": {"stub_incremental": {"updatedAt": "2025-05-01T00:00:00Z"}}}
+        stream.sync(state=state, transformer=MagicMock(transform=lambda r, s, m: r))
+
+        assert mock_write.call_count == 2
+
+    @patch("tap_teamwork.streams.abstracts.write_record")
+    @patch("tap_teamwork.streams.abstracts.metrics.record_counter")
+    def test_skips_records_older_than_bookmark(self, mock_counter, mock_write, mock_client, mock_catalog):
+        mock_counter.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_counter.return_value.__exit__ = MagicMock(return_value=False)
+
+        stream = StubIncremental(client=mock_client, catalog=mock_catalog)
+        stream.is_selected = MagicMock(return_value=True)
+        stream.get_records = MagicMock(return_value=[
+            {"id": "1", "updatedAt": "2024-01-01T00:00:00Z"},
+        ])
+
+        state = {"bookmarks": {"stub_incremental": {"updatedAt": "2025-06-01T00:00:00Z"}}}
+        stream.sync(state=state, transformer=MagicMock(transform=lambda r, s, m: r))
+
+        assert mock_write.call_count == 0
+
+
+# ─── full table sync ──────────────────────────────────────────────
+
+class TestFullTableSync:
+
+    @patch("tap_teamwork.streams.abstracts.write_record")
+    @patch("tap_teamwork.streams.abstracts.metrics.record_counter")
+    def test_writes_all_records(self, mock_counter, mock_write, mock_client, mock_catalog):
+        mock_counter.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_counter.return_value.__exit__ = MagicMock(return_value=False)
+
+        stream = StubFullTable(client=mock_client, catalog=mock_catalog)
+        stream.is_selected = MagicMock(return_value=True)
+        stream.get_records = MagicMock(return_value=[
+            {"id": "1"},
+            {"id": "2"},
+            {"id": "3"},
+        ])
+
+        state = {}
+        stream.sync(state=state, transformer=MagicMock(transform=lambda r, s, m: r))
+
+        assert mock_write.call_count == 3
+
+
+# ─── check_access ─────────────────────────────────────────────────
+
+class TestCheckAccess:
+
+    def test_accessible_stream(self, mock_client, mock_catalog):
+        """check_access returns True when API responds without 403."""
+        stream = StubIncremental(client=mock_client, catalog=mock_catalog)
+        assert stream.check_access() is True
+
+    def test_forbidden_stream(self, mock_client, mock_catalog):
+        """check_access returns False when API raises teamworkForbiddenError."""
+        mock_client.get.side_effect = teamworkForbiddenError("Forbidden")
+        stream = StubIncremental(client=mock_client, catalog=mock_catalog)
+        assert stream.check_access() is False
+
+    def test_child_stream_always_accessible(self, mock_client, mock_catalog):
+        """Child streams always return True from check_access."""
+        stream = StubChild(client=mock_client, catalog=mock_catalog)
+        assert stream.check_access() is True
+
+    def test_child_returns_true_even_when_client_would_403(self, mock_client, mock_catalog):
+        """Child streams return True regardless of client behaviour."""
+        mock_client.get.side_effect = teamworkForbiddenError("Forbidden")
+        stream = StubChild(client=mock_client, catalog=mock_catalog)
+        assert stream.check_access() is True
+
+
+# ─── sync orchestration ───────────────────────────────────────────
+
+class TestSyncOrchestration:
+
+    @patch("tap_teamwork.sync.update_currently_syncing")
+    @patch("tap_teamwork.sync._instantiate_stream")
+    @patch("tap_teamwork.sync.write_schema")
+    def test_currently_syncing_tracking(self, mock_ws, mock_inst, mock_ucs, mock_client):
+        """Verify currently_syncing is set and cleared during sync."""
+        from tap_teamwork.sync import sync as do_sync
+
+        mock_stream = MagicMock()
+        mock_stream.parent = ""
+        mock_stream.children = []
+        mock_stream.child_to_sync = []
+        mock_stream.is_selected.return_value = True
+        mock_stream.sync.return_value = 5
+        mock_inst.return_value = mock_stream
+
+        catalog = MagicMock()
+        catalog.get_selected_streams.return_value = [MagicMock(stream="projects")]
+        catalog.get_stream.return_value = MagicMock()
+
+        state = {}
+        do_sync(client=mock_client, config={}, catalog=catalog, state=state)
+
+        # currently_syncing should be set then cleared
+        assert mock_ucs.call_count == 2
+        mock_ucs.assert_any_call(state, "projects")
+        mock_ucs.assert_any_call(state, None)


### PR DESCRIPTION
# Description of change
https://qlik-dev.atlassian.net/browse/SAC-31248
Excluded unauthorized streams from catalog during discovery
Child streams are automatically excluded when their parent stream is inaccessible.
Added unit test case and updated integration test accordingly

# Manual QA steps
  - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
