### PR TITLE
Convert child streams replication method to as of parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+  * Converted child streams (`collaborators`, `pages`, `ticket_details`, `company_details`) to INCREMENTAL replication using the parent's `updatedAt` and added `ParentBaseStream` for coordinated bookmark management. [#24](https://github.com/singer-io/tap-teamwork/pull/24)
+
 ## 0.2.0
   * Streams that the credentials cannot access (403) are now excluded from the catalog during discovery instead of raising an error. [#23](https://github.com/singer-io/tap-teamwork/pull/23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.3.0
+## 1.0.0
   * Converted child streams (`collaborators`, `pages`, `ticket_details`, `company_details`) to INCREMENTAL replication using the parent's `updatedAt` and added `ParentBaseStream` for coordinated bookmark management. [#24](https://github.com/singer-io/tap-teamwork/pull/24)
 
 ## 0.2.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-teamwork",
-    version="0.3.0",
+    version="1.0.0",
     description="Singer.io tap for extracting data from Teamwork API",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="tap-teamwork",
-    version="0.2.0",
+    version="0.3.0",
     description="Singer.io tap for extracting data from Teamwork API",
     author="Stitch",
     url="http://singer.io",

--- a/tap_teamwork/schemas/collaborators.json
+++ b/tap_teamwork/schemas/collaborators.json
@@ -8,6 +8,13 @@
                 "integer"
             ]
         },
+        "spaces_updatedAt": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
         "type": {
             "type": [
                 "null",

--- a/tap_teamwork/schemas/collaborators.json
+++ b/tap_teamwork/schemas/collaborators.json
@@ -8,6 +8,12 @@
                 "integer"
             ]
         },
+        "spaceId": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
         "spaces_updatedAt": {
             "type": [
                 "null",

--- a/tap_teamwork/schemas/company_details.json
+++ b/tap_teamwork/schemas/company_details.json
@@ -1,12 +1,11 @@
 {
     "type": "object",
     "properties": {
-        "companies_updatedAt": {
+        "companyId": {
             "type": [
                 "null",
-                "string"
-            ],
-            "format": "date-time"
+                "integer"
+            ]
         },
         "address": {
             "type": [

--- a/tap_teamwork/schemas/company_details.json
+++ b/tap_teamwork/schemas/company_details.json
@@ -1,6 +1,13 @@
 {
     "type": "object",
     "properties": {
+        "companies_updatedAt": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
         "address": {
             "type": [
                 "null",

--- a/tap_teamwork/schemas/pages.json
+++ b/tap_teamwork/schemas/pages.json
@@ -1,6 +1,13 @@
 {
     "type": "object",
     "properties": {
+        "spaces_updatedAt": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
         "LinkedInstallation": {
             "type": [
                 "null",

--- a/tap_teamwork/schemas/pages.json
+++ b/tap_teamwork/schemas/pages.json
@@ -1,12 +1,11 @@
 {
     "type": "object",
     "properties": {
-        "spaces_updatedAt": {
+        "spaceId": {
             "type": [
                 "null",
-                "string"
-            ],
-            "format": "date-time"
+                "integer"
+            ]
         },
         "LinkedInstallation": {
             "type": [

--- a/tap_teamwork/schemas/ticket_details.json
+++ b/tap_teamwork/schemas/ticket_details.json
@@ -1,12 +1,11 @@
 {
     "type": "object",
     "properties": {
-        "tickets_updatedAt": {
+        "ticketId": {
             "type": [
                 "null",
-                "string"
-            ],
-            "format": "date-time"
+                "integer"
+            ]
         },
         "id": {
             "type": [

--- a/tap_teamwork/schemas/ticket_details.json
+++ b/tap_teamwork/schemas/ticket_details.json
@@ -1,6 +1,13 @@
 {
     "type": "object",
     "properties": {
+        "tickets_updatedAt": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
         "id": {
             "type": [
                 "null",

--- a/tap_teamwork/streams/abstracts.py
+++ b/tap_teamwork/streams/abstracts.py
@@ -341,11 +341,13 @@ class ParentBaseStream(IncrementalStream):
         """Return min(parent_bookmark, child_1_bookmark, …) using datetime comparison."""
         min_bookmark = super().get_bookmark(state, stream) if self.is_selected() else None
         min_dt = self._parse_utc(min_bookmark) if min_bookmark else None
-        bookmark_key = f"{self.tap_stream_id}_{self.replication_keys[0]}"
 
         for child in self.child_to_sync:
+            child_rk = child.replication_keys[0] if child.replication_keys else None
+            if not child_rk:
+                continue
             child_bookmark = super().get_bookmark(
-                state, child.tap_stream_id, key=bookmark_key
+                state, child.tap_stream_id, key=child_rk
             )
             child_dt = self._parse_utc(child_bookmark) if child_bookmark else None
             if child_dt and (min_dt is None or child_dt < min_dt):
@@ -361,10 +363,12 @@ class ParentBaseStream(IncrementalStream):
         if self.is_selected():
             super().write_bookmark(state, stream, key=key, value=value)
 
-        bookmark_key = f"{self.tap_stream_id}_{self.replication_keys[0]}"
         for child in self.child_to_sync:
+            child_rk = child.replication_keys[0] if child.replication_keys else None
+            if not child_rk:
+                continue
             super().write_bookmark(
-                state, child.tap_stream_id, key=bookmark_key, value=value
+                state, child.tap_stream_id, key=child_rk, value=value
             )
 
         return state

--- a/tap_teamwork/streams/abstracts.py
+++ b/tap_teamwork/streams/abstracts.py
@@ -338,15 +338,19 @@ class ParentBaseStream(IncrementalStream):
     """
 
     def get_bookmark(self, state: dict, stream: str, key: Any = None) -> str:
-        """Return min(parent_bookmark, child_1_bookmark, …)."""
+        """Return min(parent_bookmark, child_1_bookmark, …) using datetime comparison."""
         min_bookmark = super().get_bookmark(state, stream) if self.is_selected() else None
+        min_dt = self._parse_utc(min_bookmark) if min_bookmark else None
         bookmark_key = f"{self.tap_stream_id}_{self.replication_keys[0]}"
 
         for child in self.child_to_sync:
             child_bookmark = super().get_bookmark(
                 state, child.tap_stream_id, key=bookmark_key
             )
-            min_bookmark = min(min_bookmark, child_bookmark) if min_bookmark else child_bookmark
+            child_dt = self._parse_utc(child_bookmark) if child_bookmark else None
+            if child_dt and (min_dt is None or child_dt < min_dt):
+                min_dt = child_dt
+                min_bookmark = child_bookmark
 
         return min_bookmark or self.client.config.get("start_date", "1970-01-01T00:00:00Z")
 

--- a/tap_teamwork/streams/abstracts.py
+++ b/tap_teamwork/streams/abstracts.py
@@ -330,6 +330,42 @@ class IncrementalStream(BaseStream):
         return written
 
 
+class ParentBaseStream(IncrementalStream):
+    """Base class for incremental streams that own the bookmark of their child streams.
+
+    Ensures the parent re-fetches from the oldest bookmark across itself and all
+    children, and propagates its bookmark value to every child on each write.
+    """
+
+    def get_bookmark(self, state: dict, stream: str, key: Any = None) -> str:
+        """Return min(parent_bookmark, child_1_bookmark, …)."""
+        min_bookmark = super().get_bookmark(state, stream) if self.is_selected() else None
+        bookmark_key = f"{self.tap_stream_id}_{self.replication_keys[0]}"
+
+        for child in self.child_to_sync:
+            child_bookmark = super().get_bookmark(
+                state, child.tap_stream_id, key=bookmark_key
+            )
+            min_bookmark = min(min_bookmark, child_bookmark) if min_bookmark else child_bookmark
+
+        return min_bookmark or self.client.config.get("start_date", "1970-01-01T00:00:00Z")
+
+    def write_bookmark(
+        self, state: dict, stream: str, key: Any = None, value: Any = None
+    ) -> Dict:
+        """Advance parent bookmark and write the same value to all child streams."""
+        if self.is_selected():
+            super().write_bookmark(state, stream, key=key, value=value)
+
+        bookmark_key = f"{self.tap_stream_id}_{self.replication_keys[0]}"
+        for child in self.child_to_sync:
+            super().write_bookmark(
+                state, child.tap_stream_id, key=bookmark_key, value=value
+            )
+
+        return state
+
+
 class FullTableStream(BaseStream):
     """Base class for full-table sync streams."""
 
@@ -347,6 +383,7 @@ class FullTableStream(BaseStream):
         written = 0
         with metrics.record_counter(self.tap_stream_id) as counter:
             for record in self.get_records():
+                record = self.modify_object(record, parent_obj)
                 transformed_record = transformer.transform(
                     record, self.schema, self.metadata
                 )

--- a/tap_teamwork/streams/collaborators.py
+++ b/tap_teamwork/streams/collaborators.py
@@ -9,8 +9,8 @@ class Collaborators(FullTableStream):
     tap_stream_id = "collaborators"
     parent = "spaces"
     key_properties = ["id"]
-    replication_method = "FULL_TABLE"
-    replication_keys: List[str] = []
+    replication_method = "INCREMENTAL"
+    replication_keys: List[str] = ["spaces_updatedAt"]
     data_key = "space.collaborators"
 
     def get_url_endpoint(self, parent_obj: Optional[Dict[str, Any]] = None) -> str:
@@ -24,6 +24,12 @@ class Collaborators(FullTableStream):
         LOGGER.info("Fetching collaborators for id=%s", space_id)
 
         return self.client.build_url(f"spaces/api/v1/spaces/{space_id}/collaborators.json")
+
+    def modify_object(self, record: Dict[str, Any], parent_record: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Add parent space's updatedAt (used as replication key) to each record."""
+        if isinstance(record, dict) and parent_record and isinstance(parent_record, dict):
+            record["spaces_updatedAt"] = parent_record.get("updatedAt")
+        return record
 
     def get_child_context(
         self, record: Dict[str, Any], context: Optional[Dict[str, Any]]

--- a/tap_teamwork/streams/collaborators.py
+++ b/tap_teamwork/streams/collaborators.py
@@ -8,7 +8,7 @@ LOGGER = get_logger()
 class Collaborators(FullTableStream):
     tap_stream_id = "collaborators"
     parent = "spaces"
-    key_properties = ["id"]
+    key_properties = ["id", "spaceId"]
     replication_method = "INCREMENTAL"
     replication_keys: List[str] = ["spaces_updatedAt"]
     data_key = "space.collaborators"
@@ -26,9 +26,10 @@ class Collaborators(FullTableStream):
         return self.client.build_url(f"spaces/api/v1/spaces/{space_id}/collaborators.json")
 
     def modify_object(self, record: Dict[str, Any], parent_record: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Add parent space's updatedAt (used as replication key) to each record."""
+        """Add parent space's updatedAt (used as replication key) and spaceId to each record."""
         if isinstance(record, dict) and parent_record and isinstance(parent_record, dict):
             record["spaces_updatedAt"] = parent_record.get("updatedAt")
+            record.setdefault("spaceId", parent_record.get("id"))
         return record
 
     def get_child_context(

--- a/tap_teamwork/streams/companies.py
+++ b/tap_teamwork/streams/companies.py
@@ -1,12 +1,12 @@
 from typing import List, Optional, Dict
-from tap_teamwork.streams.abstracts import IncrementalStream, BaseStream
+from tap_teamwork.streams.abstracts import ParentBaseStream, BaseStream
 from singer import get_logger
 from datetime import datetime, timezone
 
 LOGGER = get_logger()
 
 
-class Companies(IncrementalStream):
+class Companies(ParentBaseStream):
     tap_stream_id = "companies"
     path = "desk/api/v2/companies.json"
     data_key = "companies"

--- a/tap_teamwork/streams/company_details.py
+++ b/tap_teamwork/streams/company_details.py
@@ -11,9 +11,9 @@ class CompanyDetails(BaseStream):
     parent = "companies"
     path = "desk/api/v2/companies/{companyId}.json"
 
-    key_properties = ["id"]
+    key_properties = ["id", "companyId"]
     replication_method = "INCREMENTAL"
-    replication_keys: list = ["companies_updatedAt"]
+    replication_keys: list = ["updatedAt"]
     data_key = "company"
 
     def get_child_context(
@@ -32,9 +32,9 @@ class CompanyDetails(BaseStream):
         if not record:
             return 0
 
-        # Inject parent company's updatedAt as replication key
+        # Inject parent company id if not present in response
         if parent_obj:
-            record["companies_updatedAt"] = parent_obj.get("updatedAt")
+            record.setdefault("companyId", company_id)
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             transformed = transformer.transform(record, self.schema, self.metadata)

--- a/tap_teamwork/streams/company_details.py
+++ b/tap_teamwork/streams/company_details.py
@@ -38,7 +38,7 @@ class CompanyDetails(BaseStream):
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             transformed = transformer.transform(record, self.schema, self.metadata)
-            if transformed:
+            if transformed and self.is_selected():
                 singer.write_record(self.tap_stream_id, transformed)
                 counter.increment()
             return counter.value

--- a/tap_teamwork/streams/company_details.py
+++ b/tap_teamwork/streams/company_details.py
@@ -12,8 +12,8 @@ class CompanyDetails(BaseStream):
     path = "desk/api/v2/companies/{companyId}.json"
 
     key_properties = ["id"]
-    replication_method = "FULL_TABLE"
-    replication_keys: list = []
+    replication_method = "INCREMENTAL"
+    replication_keys: list = ["companies_updatedAt"]
     data_key = "company"
 
     def get_child_context(
@@ -31,6 +31,10 @@ class CompanyDetails(BaseStream):
         record = payload.get(self.data_key) if isinstance(payload, dict) else None
         if not record:
             return 0
+
+        # Inject parent company's updatedAt as replication key
+        if parent_obj:
+            record["companies_updatedAt"] = parent_obj.get("updatedAt")
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             transformed = transformer.transform(record, self.schema, self.metadata)

--- a/tap_teamwork/streams/pages.py
+++ b/tap_teamwork/streams/pages.py
@@ -9,8 +9,8 @@ class Pages(FullTableStream):
     tap_stream_id = "pages"
     parent = "spaces"
     key_properties = ["id"]
-    replication_method = "FULL_TABLE"
-    replication_keys: List[str] = []
+    replication_method = "INCREMENTAL"
+    replication_keys: List[str] = ["spaces_updatedAt"]
     data_key = "page"
 
     def _collect_page_ids(self, node: Dict[str, Any]) -> List[int]:
@@ -60,6 +60,10 @@ class Pages(FullTableStream):
                 record = detail_resp.get("page")
                 if not record:
                     continue
+
+                # Inject parent space's updatedAt as replication key
+                if parent_obj:
+                    record["spaces_updatedAt"] = parent_obj.get("updatedAt")
 
                 transformed = transformer.transform(
                     record, self.schema, self.metadata

--- a/tap_teamwork/streams/pages.py
+++ b/tap_teamwork/streams/pages.py
@@ -8,9 +8,9 @@ LOGGER = get_logger()
 class Pages(FullTableStream):
     tap_stream_id = "pages"
     parent = "spaces"
-    key_properties = ["id"]
+    key_properties = ["id", "spaceId"]
     replication_method = "INCREMENTAL"
-    replication_keys: List[str] = ["spaces_updatedAt"]
+    replication_keys: List[str] = ["updatedAt"]
     data_key = "page"
 
     def _collect_page_ids(self, node: Dict[str, Any]) -> List[int]:
@@ -61,9 +61,8 @@ class Pages(FullTableStream):
                 if not record:
                     continue
 
-                # Inject parent space's updatedAt as replication key
-                if parent_obj:
-                    record["spaces_updatedAt"] = parent_obj.get("updatedAt")
+                # Inject parent space id if not present in response
+                record.setdefault("spaceId", space_id)
 
                 transformed = transformer.transform(
                     record, self.schema, self.metadata

--- a/tap_teamwork/streams/spaces.py
+++ b/tap_teamwork/streams/spaces.py
@@ -1,12 +1,12 @@
 from typing import List, Optional, Dict
 from datetime import datetime, timezone
-from tap_teamwork.streams.abstracts import IncrementalStream, BaseStream
+from tap_teamwork.streams.abstracts import ParentBaseStream, BaseStream
 from singer import get_logger
 
 LOGGER = get_logger()
 
 
-class Spaces(IncrementalStream):
+class Spaces(ParentBaseStream):
     tap_stream_id = "spaces"
     path = "spaces/api/v1/spaces.json"
     data_key = "spaces"

--- a/tap_teamwork/streams/ticket_details.py
+++ b/tap_teamwork/streams/ticket_details.py
@@ -9,8 +9,8 @@ class TicketDetails(FullTableStream):
     tap_stream_id = "ticket_details"
     parent = "tickets"
     key_properties = ["id"]
-    replication_method = "FULL_TABLE"
-    replication_keys: List[str] = []
+    replication_method = "INCREMENTAL"
+    replication_keys: List[str] = ["tickets_updatedAt"]
     data_key = "ticket"
     path = "desk/v1/tickets/{ticketId}.json"
 
@@ -32,6 +32,12 @@ class TicketDetails(FullTableStream):
             raise ValueError("Missing 'ticketId' or 'id' in parent_obj")
 
         return self.client.build_url(f"desk/api/v2/tickets/{ticket_id}.json")
+
+    def modify_object(self, record: Dict[str, Any], parent_record: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Add parent ticket's updatedAt (used as replication key) to each record."""
+        if isinstance(record, dict) and parent_record and isinstance(parent_record, dict):
+            record["tickets_updatedAt"] = parent_record.get("updatedAt")
+        return record
 
     def get_child_context(
         self,

--- a/tap_teamwork/streams/ticket_details.py
+++ b/tap_teamwork/streams/ticket_details.py
@@ -8,9 +8,9 @@ LOGGER = get_logger()
 class TicketDetails(FullTableStream):
     tap_stream_id = "ticket_details"
     parent = "tickets"
-    key_properties = ["id"]
+    key_properties = ["id", "ticketId"]
     replication_method = "INCREMENTAL"
-    replication_keys: List[str] = ["tickets_updatedAt"]
+    replication_keys: List[str] = ["updatedAt"]
     data_key = "ticket"
     path = "desk/v1/tickets/{ticketId}.json"
 
@@ -34,9 +34,10 @@ class TicketDetails(FullTableStream):
         return self.client.build_url(f"desk/api/v2/tickets/{ticket_id}.json")
 
     def modify_object(self, record: Dict[str, Any], parent_record: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
-        """Add parent ticket's updatedAt (used as replication key) to each record."""
+        """Add parent ticket id to each record if not already present."""
         if isinstance(record, dict) and parent_record and isinstance(parent_record, dict):
-            record["tickets_updatedAt"] = parent_record.get("updatedAt")
+            ticket_id = parent_record.get("ticketId") or parent_record.get("id")
+            record.setdefault("ticketId", ticket_id)
         return record
 
     def get_child_context(

--- a/tap_teamwork/streams/tickets.py
+++ b/tap_teamwork/streams/tickets.py
@@ -1,6 +1,6 @@
 from typing import Dict, List, Optional
 from singer import get_logger
-from tap_teamwork.streams.abstracts import ParentBaseStream
+from tap_teamwork.streams.abstracts import ParentBaseStream, BaseStream
 
 LOGGER = get_logger()
 
@@ -15,7 +15,7 @@ class Tickets(ParentBaseStream):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.child_to_sync: List[IncrementalStream] = []
+        self.child_to_sync: List[BaseStream] = []
 
     def get_url_params(self, context: Optional[Dict] = None, next_page_token: Optional[str] = None) -> Dict:
         params = super().get_url_params(context, next_page_token)

--- a/tap_teamwork/streams/tickets.py
+++ b/tap_teamwork/streams/tickets.py
@@ -1,10 +1,10 @@
 from typing import Dict, List, Optional
 from singer import get_logger
-from tap_teamwork.streams.abstracts import IncrementalStream
+from tap_teamwork.streams.abstracts import ParentBaseStream
 
 LOGGER = get_logger()
 
-class Tickets(IncrementalStream):
+class Tickets(ParentBaseStream):
     tap_stream_id = "tickets"
     key_properties = ["id"]
     replication_method = "INCREMENTAL"

--- a/tests/base.py
+++ b/tests/base.py
@@ -77,9 +77,9 @@ class teamworkBaseTest(BaseCase):
                 cls.API_LIMIT: 100
             },
             "ticket_details": {
-                cls.PRIMARY_KEYS: { "id" },
+                cls.PRIMARY_KEYS: { "id", "ticketId" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
-                cls.REPLICATION_KEYS: {"tickets_updatedAt"},
+                cls.REPLICATION_KEYS: {"updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
@@ -119,24 +119,24 @@ class teamworkBaseTest(BaseCase):
                 cls.API_LIMIT: 100
             },
             "pages": {
-                cls.PRIMARY_KEYS: { "id" },
+                cls.PRIMARY_KEYS: { "id", "spaceId" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
-                cls.REPLICATION_KEYS: {"spaces_updatedAt"},
+                cls.REPLICATION_KEYS: {"updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
             
             "collaborators": {
-                cls.PRIMARY_KEYS: { "id" },
+                cls.PRIMARY_KEYS: { "id", "spaceId" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
                 cls.REPLICATION_KEYS: {"spaces_updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
             "company_details": {
-                cls.PRIMARY_KEYS: { "id" },
+                cls.PRIMARY_KEYS: { "id", "companyId" },
                 cls.REPLICATION_METHOD: cls.INCREMENTAL,
-                cls.REPLICATION_KEYS: {"companies_updatedAt"},
+                cls.REPLICATION_KEYS: {"updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },

--- a/tests/base.py
+++ b/tests/base.py
@@ -78,8 +78,8 @@ class teamworkBaseTest(BaseCase):
             },
             "ticket_details": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"tickets_updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
@@ -120,23 +120,23 @@ class teamworkBaseTest(BaseCase):
             },
             "pages": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"spaces_updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
             
             "collaborators": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"spaces_updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },
             "company_details": {
                 cls.PRIMARY_KEYS: { "id" },
-                cls.REPLICATION_METHOD: cls.FULL_TABLE,
-                cls.REPLICATION_KEYS: set(),
+                cls.REPLICATION_METHOD: cls.INCREMENTAL,
+                cls.REPLICATION_KEYS: {"companies_updatedAt"},
                 cls.OBEYS_START_DATE: False,
                 cls.API_LIMIT: 100
             },

--- a/tests/unittests/test_parent_child_streams.py
+++ b/tests/unittests/test_parent_child_streams.py
@@ -1,0 +1,326 @@
+"""
+Unit tests for ParentBaseStream bookmark behaviour and child stream
+INCREMENTAL replication with parent's updatedAt propagation.
+
+Covers:
+- ParentBaseStream.get_bookmark returns min across parent and children
+- ParentBaseStream.write_bookmark propagates to child streams
+- Collaborators modify_object injects spaces_updatedAt from parent
+- TicketDetails modify_object injects tickets_updatedAt from parent
+- Pages sync injects spaces_updatedAt from parent
+- CompanyDetails sync injects companies_updatedAt from parent
+- Child streams have correct replication_method and replication_keys
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tap_teamwork.streams.abstracts import ParentBaseStream, FullTableStream
+
+
+# ---- Helpers ----
+
+def make_mock_client(config=None):
+    client = MagicMock()
+    client.config = config or {"start_date": "2026-01-01T00:00:00Z"}
+    client.base_url = "https://example.com"
+    client.build_url.side_effect = lambda path: f"https://example.com/{path.lstrip('/')}"
+    return client
+
+
+def make_mock_catalog_entry():
+    mock_catalog = MagicMock()
+    mock_catalog.schema.to_dict.return_value = {
+        "type": "object",
+        "properties": {"id": {"type": "integer"}}
+    }
+    mock_catalog.metadata = []
+    return mock_catalog
+
+
+# ---- ParentBaseStream Bookmark Tests ----
+
+class TestParentBaseStreamBookmark(unittest.TestCase):
+    """Tests for ParentBaseStream bookmark behaviour."""
+
+    def _make_spaces_with_children(self, config=None):
+        from tap_teamwork.streams.spaces import Spaces
+        from tap_teamwork.streams.collaborators import Collaborators
+        from tap_teamwork.streams.pages import Pages
+
+        if config is None:
+            config = {"start_date": "2026-01-01T00:00:00Z"}
+        client = make_mock_client(config)
+        stream = Spaces(client=client, catalog=make_mock_catalog_entry())
+        collaborators = Collaborators(client=client, catalog=make_mock_catalog_entry())
+        pages = Pages(client=client, catalog=make_mock_catalog_entry())
+        stream.child_to_sync = [collaborators, pages]
+        return stream, collaborators, pages
+
+    def _make_tickets_with_children(self, config=None):
+        from tap_teamwork.streams.tickets import Tickets
+        from tap_teamwork.streams.ticket_details import TicketDetails
+
+        if config is None:
+            config = {"start_date": "2026-01-01T00:00:00Z"}
+        client = make_mock_client(config)
+        stream = Tickets(client=client, catalog=make_mock_catalog_entry())
+        details = TicketDetails(client=client, catalog=make_mock_catalog_entry())
+        stream.child_to_sync = [details]
+        return stream, details
+
+    def _make_companies_with_children(self, config=None):
+        from tap_teamwork.streams.companies import Companies
+        from tap_teamwork.streams.company_details import CompanyDetails
+
+        if config is None:
+            config = {"start_date": "2026-01-01T00:00:00Z"}
+        client = make_mock_client(config)
+        stream = Companies(client=client, catalog=make_mock_catalog_entry())
+        details = CompanyDetails(client=client, catalog=make_mock_catalog_entry())
+        stream.child_to_sync = [details]
+        return stream, details
+
+    def test_spaces_extends_parent_base_stream(self):
+        from tap_teamwork.streams.spaces import Spaces
+        self.assertTrue(issubclass(Spaces, ParentBaseStream))
+
+    def test_tickets_extends_parent_base_stream(self):
+        from tap_teamwork.streams.tickets import Tickets
+        self.assertTrue(issubclass(Tickets, ParentBaseStream))
+
+    def test_companies_extends_parent_base_stream(self):
+        from tap_teamwork.streams.companies import Companies
+        self.assertTrue(issubclass(Companies, ParentBaseStream))
+
+    def test_get_bookmark_returns_min_across_parent_and_children(self):
+        """When children have an older bookmark, parent must re-process from children's date."""
+        state = {
+            "bookmarks": {
+                "spaces": {"updatedAt": "2026-06-01T00:00:00Z"},
+                "collaborators": {"spaces_updatedAt": "2026-03-01T00:00:00Z"},
+                "pages": {"spaces_updatedAt": "2026-05-01T00:00:00Z"},
+            }
+        }
+        stream, _, _ = self._make_spaces_with_children()
+        bookmark = stream.get_bookmark(state, "spaces")
+        self.assertEqual(bookmark, "2026-03-01T00:00:00Z")
+
+    def test_get_bookmark_falls_back_to_start_date_when_no_state(self):
+        stream, _, _ = self._make_spaces_with_children()
+        bookmark = stream.get_bookmark({}, "spaces")
+        self.assertEqual(bookmark, "2026-01-01T00:00:00Z")
+
+    def test_get_bookmark_uses_parent_when_parent_is_oldest(self):
+        """When parent has the oldest bookmark, it should be returned."""
+        state = {
+            "bookmarks": {
+                "spaces": {"updatedAt": "2026-02-01T00:00:00Z"},
+                "collaborators": {"spaces_updatedAt": "2026-05-01T00:00:00Z"},
+                "pages": {"spaces_updatedAt": "2026-06-01T00:00:00Z"},
+            }
+        }
+        stream, _, _ = self._make_spaces_with_children()
+        with patch.object(stream, "is_selected", return_value=True):
+            bookmark = stream.get_bookmark(state, "spaces")
+        self.assertEqual(bookmark, "2026-02-01T00:00:00Z")
+
+    def test_write_bookmark_propagates_to_children(self):
+        """Children's bookmarks must be stored under '{parent}_updatedAt'."""
+        state = {"bookmarks": {}}
+        stream, _, _ = self._make_spaces_with_children()
+        stream.write_bookmark(state, "spaces", key="updatedAt", value="2026-07-01T00:00:00Z")
+        self.assertEqual(
+            state["bookmarks"]["collaborators"]["spaces_updatedAt"],
+            "2026-07-01T00:00:00.000000Z"
+        )
+        self.assertEqual(
+            state["bookmarks"]["pages"]["spaces_updatedAt"],
+            "2026-07-01T00:00:00.000000Z"
+        )
+
+    def test_write_bookmark_propagates_to_ticket_details(self):
+        state = {"bookmarks": {}}
+        stream, _ = self._make_tickets_with_children()
+        stream.write_bookmark(state, "tickets", key="updatedAt", value="2026-07-15T00:00:00Z")
+        self.assertEqual(
+            state["bookmarks"]["ticket_details"]["tickets_updatedAt"],
+            "2026-07-15T00:00:00.000000Z"
+        )
+
+    def test_write_bookmark_propagates_to_company_details(self):
+        state = {"bookmarks": {}}
+        stream, _ = self._make_companies_with_children()
+        stream.write_bookmark(state, "companies", key="updatedAt", value="2026-07-20T00:00:00Z")
+        self.assertEqual(
+            state["bookmarks"]["company_details"]["companies_updatedAt"],
+            "2026-07-20T00:00:00.000000Z"
+        )
+
+    def test_write_bookmark_writes_parent_when_selected(self):
+        state = {"bookmarks": {}}
+        stream, _, _ = self._make_spaces_with_children()
+        with patch.object(stream, "is_selected", return_value=True):
+            stream.write_bookmark(state, "spaces", key="updatedAt", value="2026-07-01T00:00:00Z")
+        self.assertIn("spaces", state["bookmarks"])
+        self.assertIn("updatedAt", state["bookmarks"]["spaces"])
+
+
+# ---- Child Stream Attribute Tests ----
+
+class TestCollaboratorsStream(unittest.TestCase):
+    """Tests for Collaborators stream — INCREMENTAL with spaces_updatedAt from parent."""
+
+    def _make_stream(self):
+        from tap_teamwork.streams.collaborators import Collaborators
+        client = make_mock_client()
+        return Collaborators(client=client, catalog=make_mock_catalog_entry())
+
+    def test_collaborators_replication_method_is_incremental(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_method, "INCREMENTAL")
+
+    def test_collaborators_replication_key_is_spaces_updatedAt(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_keys, ["spaces_updatedAt"])
+
+    def test_modify_object_sets_spaces_updatedAt_from_parent(self):
+        stream = self._make_stream()
+        parent = {"id": 100, "updatedAt": "2026-03-01T10:00:00Z"}
+        record = {"id": 616263, "type": "users"}
+        result = stream.modify_object(record, parent)
+        self.assertEqual(result["spaces_updatedAt"], "2026-03-01T10:00:00Z")
+
+    def test_modify_object_no_parent_returns_record_unchanged(self):
+        stream = self._make_stream()
+        record = {"id": 616263, "type": "users"}
+        result = stream.modify_object(record, None)
+        self.assertNotIn("spaces_updatedAt", result)
+
+
+class TestPagesStream(unittest.TestCase):
+    """Tests for Pages stream — INCREMENTAL with spaces_updatedAt from parent."""
+
+    def _make_stream(self):
+        from tap_teamwork.streams.pages import Pages
+        client = make_mock_client()
+        return Pages(client=client, catalog=make_mock_catalog_entry())
+
+    def test_pages_replication_method_is_incremental(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_method, "INCREMENTAL")
+
+    def test_pages_replication_key_is_spaces_updatedAt(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_keys, ["spaces_updatedAt"])
+
+    @patch("singer.write_record")
+    @patch("singer.metrics.record_counter")
+    def test_sync_injects_spaces_updatedAt(self, mock_counter, mock_write_record):
+        """Pages sync should inject parent's updatedAt into each page record."""
+        from tap_teamwork.streams.pages import Pages
+
+        mock_counter_inst = MagicMock()
+        mock_counter_inst.__enter__ = MagicMock(return_value=mock_counter_inst)
+        mock_counter_inst.__exit__ = MagicMock(return_value=False)
+        mock_counter.return_value = mock_counter_inst
+
+        client = make_mock_client()
+        # First call: list pages tree; Second call: fetch page detail
+        client.get.side_effect = [
+            {"pages": {"id": 1, "childPages": []}},
+            {"page": {"id": 1, "title": "Test Page", "updatedAt": "2026-01-15T00:00:00Z"}},
+        ]
+        stream = Pages(client=client, catalog=make_mock_catalog_entry())
+        stream.schema = {"type": "object", "properties": {}}
+        stream.metadata = {}
+
+        transformer = MagicMock()
+        transformer.transform.side_effect = lambda r, s, m: r
+
+        with patch.object(stream, "is_selected", return_value=True):
+            parent_obj = {"id": 42, "updatedAt": "2026-06-01T00:00:00Z"}
+            stream.sync(state={}, transformer=transformer, parent_obj=parent_obj)
+
+        # Check that transform was called with record containing spaces_updatedAt
+        call_args = transformer.transform.call_args[0][0]
+        self.assertEqual(call_args["spaces_updatedAt"], "2026-06-01T00:00:00Z")
+
+
+class TestTicketDetailsStream(unittest.TestCase):
+    """Tests for TicketDetails stream — INCREMENTAL with tickets_updatedAt from parent."""
+
+    def _make_stream(self):
+        from tap_teamwork.streams.ticket_details import TicketDetails
+        client = make_mock_client()
+        return TicketDetails(client=client, catalog=make_mock_catalog_entry())
+
+    def test_ticket_details_replication_method_is_incremental(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_method, "INCREMENTAL")
+
+    def test_ticket_details_replication_key_is_tickets_updatedAt(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_keys, ["tickets_updatedAt"])
+
+    def test_modify_object_sets_tickets_updatedAt_from_parent(self):
+        stream = self._make_stream()
+        parent = {"id": 55, "updatedAt": "2026-05-10T08:00:00Z"}
+        record = {"id": 1, "subject": "Test ticket"}
+        result = stream.modify_object(record, parent)
+        self.assertEqual(result["tickets_updatedAt"], "2026-05-10T08:00:00Z")
+
+    def test_modify_object_no_parent_returns_record_unchanged(self):
+        stream = self._make_stream()
+        record = {"id": 1, "subject": "Test ticket"}
+        result = stream.modify_object(record, None)
+        self.assertNotIn("tickets_updatedAt", result)
+
+
+class TestCompanyDetailsStream(unittest.TestCase):
+    """Tests for CompanyDetails stream — INCREMENTAL with companies_updatedAt from parent."""
+
+    def _make_stream(self):
+        from tap_teamwork.streams.company_details import CompanyDetails
+        client = make_mock_client()
+        return CompanyDetails(client=client, catalog=make_mock_catalog_entry())
+
+    def test_company_details_replication_method_is_incremental(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_method, "INCREMENTAL")
+
+    def test_company_details_replication_key_is_companies_updatedAt(self):
+        stream = self._make_stream()
+        self.assertEqual(stream.replication_keys, ["companies_updatedAt"])
+
+    @patch("tap_teamwork.streams.company_details.singer.write_record")
+    @patch("tap_teamwork.streams.company_details.metrics.record_counter")
+    def test_sync_injects_companies_updatedAt(self, mock_counter, mock_write_record):
+        """CompanyDetails sync should inject parent's updatedAt into the record."""
+        from tap_teamwork.streams.company_details import CompanyDetails
+
+        mock_counter_inst = MagicMock()
+        mock_counter_inst.__enter__ = MagicMock(return_value=mock_counter_inst)
+        mock_counter_inst.__exit__ = MagicMock(return_value=False)
+        mock_counter_inst.value = 1
+        mock_counter.return_value = mock_counter_inst
+
+        client = make_mock_client()
+        client.get.return_value = {"company": {"id": 10, "name": "Acme"}}
+        stream = CompanyDetails(client=client, catalog=make_mock_catalog_entry())
+        stream.schema = {"type": "object", "properties": {}}
+        stream.metadata = {}
+
+        transformer = MagicMock()
+        transformer.transform.side_effect = lambda r, s, m: r
+
+        parent_obj = {"id": 10, "updatedAt": "2026-07-20T12:00:00Z"}
+        stream.sync(state={}, transformer=transformer, parent_obj=parent_obj)
+
+        # Verify the record passed to transform includes companies_updatedAt
+        call_args = transformer.transform.call_args[0][0]
+        self.assertEqual(call_args["companies_updatedAt"], "2026-07-20T12:00:00Z")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/test_parent_child_streams.py
+++ b/tests/unittests/test_parent_child_streams.py
@@ -15,7 +15,7 @@ Covers:
 import unittest
 from unittest.mock import MagicMock, patch
 
-from tap_teamwork.streams.abstracts import ParentBaseStream, FullTableStream
+from tap_teamwork.streams.abstracts import ParentBaseStream
 
 
 # ---- Helpers ----

--- a/tests/unittests/test_parent_child_streams.py
+++ b/tests/unittests/test_parent_child_streams.py
@@ -4,11 +4,11 @@ INCREMENTAL replication with parent's updatedAt propagation.
 
 Covers:
 - ParentBaseStream.get_bookmark returns min across parent and children
-- ParentBaseStream.write_bookmark propagates to child streams
+- ParentBaseStream.write_bookmark propagates to child streams using each child's replication key
 - Collaborators modify_object injects spaces_updatedAt from parent
-- TicketDetails modify_object injects tickets_updatedAt from parent
-- Pages sync injects spaces_updatedAt from parent
-- CompanyDetails sync injects companies_updatedAt from parent
+- TicketDetails modify_object injects ticketId from parent
+- Pages sync injects spaceId from parent
+- CompanyDetails sync injects companyId from parent
 - Child streams have correct replication_method and replication_keys
 """
 
@@ -98,8 +98,10 @@ class TestParentBaseStreamBookmark(unittest.TestCase):
         state = {
             "bookmarks": {
                 "spaces": {"updatedAt": "2026-06-01T00:00:00Z"},
+                # collaborators uses spaces_updatedAt as its replication key
                 "collaborators": {"spaces_updatedAt": "2026-03-01T00:00:00Z"},
-                "pages": {"spaces_updatedAt": "2026-05-01T00:00:00Z"},
+                # pages uses updatedAt as its replication key
+                "pages": {"updatedAt": "2026-05-01T00:00:00Z"},
             }
         }
         stream, _, _ = self._make_spaces_with_children()
@@ -117,7 +119,7 @@ class TestParentBaseStreamBookmark(unittest.TestCase):
             "bookmarks": {
                 "spaces": {"updatedAt": "2026-02-01T00:00:00Z"},
                 "collaborators": {"spaces_updatedAt": "2026-05-01T00:00:00Z"},
-                "pages": {"spaces_updatedAt": "2026-06-01T00:00:00Z"},
+                "pages": {"updatedAt": "2026-06-01T00:00:00Z"},
             }
         }
         stream, _, _ = self._make_spaces_with_children()
@@ -126,16 +128,18 @@ class TestParentBaseStreamBookmark(unittest.TestCase):
         self.assertEqual(bookmark, "2026-02-01T00:00:00Z")
 
     def test_write_bookmark_propagates_to_children(self):
-        """Children's bookmarks must be stored under '{parent}_updatedAt'."""
+        """Children's bookmarks are stored under each child's own replication key."""
         state = {"bookmarks": {}}
         stream, _, _ = self._make_spaces_with_children()
         stream.write_bookmark(state, "spaces", key="updatedAt", value="2026-07-01T00:00:00Z")
+        # collaborators uses spaces_updatedAt as its replication key
         self.assertEqual(
             state["bookmarks"]["collaborators"]["spaces_updatedAt"],
             "2026-07-01T00:00:00.000000Z"
         )
+        # pages uses updatedAt as its replication key
         self.assertEqual(
-            state["bookmarks"]["pages"]["spaces_updatedAt"],
+            state["bookmarks"]["pages"]["updatedAt"],
             "2026-07-01T00:00:00.000000Z"
         )
 
@@ -143,8 +147,9 @@ class TestParentBaseStreamBookmark(unittest.TestCase):
         state = {"bookmarks": {}}
         stream, _ = self._make_tickets_with_children()
         stream.write_bookmark(state, "tickets", key="updatedAt", value="2026-07-15T00:00:00Z")
+        # ticket_details uses updatedAt as its replication key
         self.assertEqual(
-            state["bookmarks"]["ticket_details"]["tickets_updatedAt"],
+            state["bookmarks"]["ticket_details"]["updatedAt"],
             "2026-07-15T00:00:00.000000Z"
         )
 
@@ -152,8 +157,9 @@ class TestParentBaseStreamBookmark(unittest.TestCase):
         state = {"bookmarks": {}}
         stream, _ = self._make_companies_with_children()
         stream.write_bookmark(state, "companies", key="updatedAt", value="2026-07-20T00:00:00Z")
+        # company_details uses updatedAt as its replication key
         self.assertEqual(
-            state["bookmarks"]["company_details"]["companies_updatedAt"],
+            state["bookmarks"]["company_details"]["updatedAt"],
             "2026-07-20T00:00:00.000000Z"
         )
 
@@ -199,7 +205,7 @@ class TestCollaboratorsStream(unittest.TestCase):
 
 
 class TestPagesStream(unittest.TestCase):
-    """Tests for Pages stream — INCREMENTAL with spaces_updatedAt from parent."""
+    """Tests for Pages stream — INCREMENTAL using own updatedAt, with spaceId injected."""
 
     def _make_stream(self):
         from tap_teamwork.streams.pages import Pages
@@ -210,14 +216,18 @@ class TestPagesStream(unittest.TestCase):
         stream = self._make_stream()
         self.assertEqual(stream.replication_method, "INCREMENTAL")
 
-    def test_pages_replication_key_is_spaces_updatedAt(self):
+    def test_pages_replication_key_is_updatedAt(self):
         stream = self._make_stream()
-        self.assertEqual(stream.replication_keys, ["spaces_updatedAt"])
+        self.assertEqual(stream.replication_keys, ["updatedAt"])
+
+    def test_pages_key_properties_include_spaceId(self):
+        stream = self._make_stream()
+        self.assertIn("spaceId", stream.key_properties)
 
     @patch("singer.write_record")
     @patch("singer.metrics.record_counter")
-    def test_sync_injects_spaces_updatedAt(self, mock_counter, mock_write_record):
-        """Pages sync should inject parent's updatedAt into each page record."""
+    def test_sync_injects_spaceId(self, mock_counter, mock_write_record):
+        """Pages sync should inject parent space id into each page record."""
         from tap_teamwork.streams.pages import Pages
 
         mock_counter_inst = MagicMock()
@@ -242,13 +252,12 @@ class TestPagesStream(unittest.TestCase):
             parent_obj = {"id": 42, "updatedAt": "2026-06-01T00:00:00Z"}
             stream.sync(state={}, transformer=transformer, parent_obj=parent_obj)
 
-        # Check that transform was called with record containing spaces_updatedAt
         call_args = transformer.transform.call_args[0][0]
-        self.assertEqual(call_args["spaces_updatedAt"], "2026-06-01T00:00:00Z")
+        self.assertEqual(call_args["spaceId"], 42)
 
 
 class TestTicketDetailsStream(unittest.TestCase):
-    """Tests for TicketDetails stream — INCREMENTAL with tickets_updatedAt from parent."""
+    """Tests for TicketDetails stream — INCREMENTAL using own updatedAt, with ticketId injected."""
 
     def _make_stream(self):
         from tap_teamwork.streams.ticket_details import TicketDetails
@@ -259,26 +268,33 @@ class TestTicketDetailsStream(unittest.TestCase):
         stream = self._make_stream()
         self.assertEqual(stream.replication_method, "INCREMENTAL")
 
-    def test_ticket_details_replication_key_is_tickets_updatedAt(self):
+    def test_ticket_details_replication_key_is_updatedAt(self):
         stream = self._make_stream()
-        self.assertEqual(stream.replication_keys, ["tickets_updatedAt"])
+        self.assertEqual(stream.replication_keys, ["updatedAt"])
 
-    def test_modify_object_sets_tickets_updatedAt_from_parent(self):
+    def test_modify_object_injects_ticketId_from_parent(self):
         stream = self._make_stream()
         parent = {"id": 55, "updatedAt": "2026-05-10T08:00:00Z"}
-        record = {"id": 1, "subject": "Test ticket"}
+        record = {"id": 55, "subject": "Test ticket"}
         result = stream.modify_object(record, parent)
-        self.assertEqual(result["tickets_updatedAt"], "2026-05-10T08:00:00Z")
+        self.assertEqual(result["ticketId"], 55)
+
+    def test_modify_object_uses_ticketId_key_from_parent_when_available(self):
+        stream = self._make_stream()
+        parent = {"ticketId": 77, "id": 55, "updatedAt": "2026-05-10T08:00:00Z"}
+        record = {"id": 55, "subject": "Test ticket"}
+        result = stream.modify_object(record, parent)
+        self.assertEqual(result["ticketId"], 77)
 
     def test_modify_object_no_parent_returns_record_unchanged(self):
         stream = self._make_stream()
         record = {"id": 1, "subject": "Test ticket"}
         result = stream.modify_object(record, None)
-        self.assertNotIn("tickets_updatedAt", result)
+        self.assertNotIn("ticketId", result)
 
 
 class TestCompanyDetailsStream(unittest.TestCase):
-    """Tests for CompanyDetails stream — INCREMENTAL with companies_updatedAt from parent."""
+    """Tests for CompanyDetails stream — INCREMENTAL using own updatedAt, with companyId injected."""
 
     def _make_stream(self):
         from tap_teamwork.streams.company_details import CompanyDetails
@@ -289,14 +305,14 @@ class TestCompanyDetailsStream(unittest.TestCase):
         stream = self._make_stream()
         self.assertEqual(stream.replication_method, "INCREMENTAL")
 
-    def test_company_details_replication_key_is_companies_updatedAt(self):
+    def test_company_details_replication_key_is_updatedAt(self):
         stream = self._make_stream()
-        self.assertEqual(stream.replication_keys, ["companies_updatedAt"])
+        self.assertEqual(stream.replication_keys, ["updatedAt"])
 
     @patch("tap_teamwork.streams.company_details.singer.write_record")
     @patch("tap_teamwork.streams.company_details.metrics.record_counter")
-    def test_sync_injects_companies_updatedAt(self, mock_counter, mock_write_record):
-        """CompanyDetails sync should inject parent's updatedAt into the record."""
+    def test_sync_injects_companyId(self, mock_counter, mock_write_record):
+        """CompanyDetails sync should inject the parent company id into the record."""
         from tap_teamwork.streams.company_details import CompanyDetails
 
         mock_counter_inst = MagicMock()
@@ -306,7 +322,7 @@ class TestCompanyDetailsStream(unittest.TestCase):
         mock_counter.return_value = mock_counter_inst
 
         client = make_mock_client()
-        client.get.return_value = {"company": {"id": 10, "name": "Acme"}}
+        client.get.return_value = {"company": {"id": 10, "name": "Acme", "updatedAt": "2026-07-20T12:00:00Z"}}
         stream = CompanyDetails(client=client, catalog=make_mock_catalog_entry())
         stream.schema = {"type": "object", "properties": {}}
         stream.metadata = {}
@@ -317,9 +333,8 @@ class TestCompanyDetailsStream(unittest.TestCase):
         parent_obj = {"id": 10, "updatedAt": "2026-07-20T12:00:00Z"}
         stream.sync(state={}, transformer=transformer, parent_obj=parent_obj)
 
-        # Verify the record passed to transform includes companies_updatedAt
         call_args = transformer.transform.call_args[0][0]
-        self.assertEqual(call_args["companies_updatedAt"], "2026-07-20T12:00:00Z")
+        self.assertEqual(call_args["companyId"], 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Description of change
This PR updates the child streams to use INCREMENTAL replication (via ChildBaseStream) by propagating the parent project’s updated_at into each emitted record, along with schema/test updates and a version bump. [SAC-31629](https://qlik-dev.atlassian.net/browse/SAC-31629)

Changes:

- Convert Child streams from FullTableStream to ChildBaseStream and switch replication method to INCREMENTAL with replication_keys = ["updated_at"].
- Add updated_at to the branches and users JSON schemas and add unit tests covering the new behavior.

# Manual QA steps
 - [x]  Discovery: Running
 - [x]  Sync: Running
 - [x]  Unit Tests: Running
 - [x]  Integration test: Running
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
